### PR TITLE
添加除法运算实现

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@
 ## 3.导入项目
 
 ### 3.1.gradle方式的引入
-```text
+```groovy
 dependencies {
-    compile 'com.pig4cloud.plugin:easy-captcha:2.2.2'
+    implementation 'com.pig4cloud.plugin:easy-captcha:2.2.2'
 }
 ```
 
@@ -222,24 +222,44 @@ public class Test {
 ```
 
 > 注意：<br/>
-> &emsp;算术验证码的len表示是几位数运算，而其他验证码的len表示验证码的位数，算术验证码的text()表示的是公式的结果，
-> 对于算术验证码，你应该把公式的结果存储session，而不是公式。
+> &emsp;1. 算术验证码的len表示是几位数运算，而其他验证码的len表示验证码的位数，算术验证码的text()表示的是公式的结果，
+> 对于算术验证码，你应该把公式的结果存储session，而不是公式。  
+> &emsp;2. 由于部分字体库的问题，除号可能无法显示
 
 ### 5.2.验证码字符类型
 
- 类型 | 描述 
- :--- | :--- 
- TYPE_DEFAULT | 数字和字母混合 
- TYPE_ONLY_NUMBER | 纯数字
- TYPE_ONLY_CHAR | 纯字母 
- TYPE_ONLY_UPPER | 纯大写字母
- TYPE_ONLY_LOWER | 纯小写字母
- TYPE_NUM_AND_UPPER | 数字和大写字母
+#### 算数验证码
+
+| 值   | 描述   |
+|-----|------|
+| 2   | 加法   |
+| 3   | 加减   |
+| 4   | 加减乘  |
+| 5   | 加减乘除 |
 
 使用方法：
+
+```java
+    ArithmeticCaptcha arithmeticCaptcha=new ArithmeticCaptcha();
+    arithmeticCaptcha.supportAlgorithmSign(5);
 ```
-SpecCaptcha captcha = new SpecCaptcha(130, 48, 5);
-captcha.setCharType(Captcha.TYPE_ONLY_NUMBER);
+
+#### 验证码
+
+| 类型                 | 描述      |
+|--------------------|---------|
+| TYPE_DEFAULT       | 数字和字母混合 |
+| TYPE_ONLY_NUMBER   | 纯数字     |
+| TYPE_ONLY_CHAR     | 纯字母     |
+| TYPE_ONLY_UPPER    | 纯大写字母   |
+| TYPE_ONLY_LOWER    | 纯小写字母   |
+| TYPE_NUM_AND_UPPER | 数字和大写字母 |
+
+使用方法：
+
+```java
+    SpecCaptcha captcha=new SpecCaptcha(130,48,5);
+    captcha.setCharType(Captcha.TYPE_ONLY_NUMBER);
 ```
 
 > 只有`SpecCaptcha`和`GifCaptcha`设置才有效果。
@@ -247,18 +267,18 @@ captcha.setCharType(Captcha.TYPE_ONLY_NUMBER);
 ### 5.3.字体设置
 内置字体：
 
- 字体 | 效果 
- :--- | :--- 
- Captcha.FONT_1 |  ![](https://s2.ax1x.com/2019/08/23/msMe6U.png)
- Captcha.FONT_2 | ![](https://s2.ax1x.com/2019/08/23/msMAf0.png)
- Captcha.FONT_3 |  ![](https://s2.ax1x.com/2019/08/23/msMCwj.png)
- Captcha.FONT_4 | ![](https://s2.ax1x.com/2019/08/23/msM9mQ.png)
- Captcha.FONT_5 | ![](https://s2.ax1x.com/2019/08/23/msKz6S.png)
- Captcha.FONT_6 | ![](https://s2.ax1x.com/2019/08/23/msKxl8.png)
- Captcha.FONT_7 | ![](https://s2.ax1x.com/2019/08/23/msMPTs.png)
- Captcha.FONT_8 | ![](https://s2.ax1x.com/2019/08/23/msMmXF.png)
- Captcha.FONT_9 | ![](https://s2.ax1x.com/2019/08/23/msMVpV.png)
- Captcha.FONT_10 | ![](https://s2.ax1x.com/2019/08/23/msMZlT.png)
+| 字体              | 效果                                             |
+|-----------------|------------------------------------------------|
+| Captcha.FONT_1  | ![](https://s2.ax1x.com/2019/08/23/msMe6U.png) |
+| Captcha.FONT_2  | ![](https://s2.ax1x.com/2019/08/23/msMAf0.png) |
+| Captcha.FONT_3  | ![](https://s2.ax1x.com/2019/08/23/msMCwj.png) |
+| Captcha.FONT_4  | ![](https://s2.ax1x.com/2019/08/23/msM9mQ.png) |
+| Captcha.FONT_5  | ![](https://s2.ax1x.com/2019/08/23/msKz6S.png) |
+| Captcha.FONT_6  | ![](https://s2.ax1x.com/2019/08/23/msKxl8.png) |
+| Captcha.FONT_7  | ![](https://s2.ax1x.com/2019/08/23/msMPTs.png) |
+| Captcha.FONT_8  | ![](https://s2.ax1x.com/2019/08/23/msMmXF.png) |
+| Captcha.FONT_9  | ![](https://s2.ax1x.com/2019/08/23/msMVpV.png) |
+| Captcha.FONT_10 | ![](https://s2.ax1x.com/2019/08/23/msMZlT.png) |
 
 使用方法：
 ```
@@ -338,7 +358,7 @@ public class CaptchaController {
     $.post('/login', {
         verKey: verKey,
         verCode: '8u6h',
-        username: 'admin'，
+        username: 'admin',
         password: 'admin'
     }, function(res) {
         console.log(res);
@@ -358,16 +378,19 @@ public class CaptchaController {
 
 ## 8.更新日志
 
+- **2023-01-21 (v2.2.3)**
+    - 增加除法运算
+
 - **2019-08-23 (v1.6.2)**
     - 增加10种漂亮的内置字体，不依赖系统字体
-    
+
     - 增加算术验证码，运算位数可自由配置
     - 增加输出base64编码的功能
     - 增加贝塞尔曲线作为干扰线
-    
+
 - **2018-08-09 (v1.5.0)**
     - 增加纯大写字母、纯小写字母、数字和大写字母配置
-    
+
     - 增加中文验证码、中文gif验证码
     - 增加抗锯齿效果，优化文字颜色
     - 增加CaptchaUtil便于Web项目使用

--- a/captcha-core/src/main/java/com/pig4cloud/captcha/base/ArithmeticCaptchaAbstract.java
+++ b/captcha-core/src/main/java/com/pig4cloud/captcha/base/ArithmeticCaptchaAbstract.java
@@ -3,15 +3,28 @@ package com.pig4cloud.captcha.base;
 import com.googlecode.aviator.AviatorEvaluator;
 import com.pig4cloud.captcha.engine.Symbol;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * 算术验证码抽象类 Created by 王帆 on 2019-08-23 上午 10:08.
  */
 public abstract class ArithmeticCaptchaAbstract extends Captcha {
-	// 计算公式
+
+	/**
+	 * 计算公式
+	 */
 	private String arithmeticString;
 
+	/**
+	 * 难度
+	 */
 	protected static int difficulty = 10;
-	protected static int algorithmSign = 4;
+
+	/**
+	 * 表达式复杂度
+	 */
+	protected static int algorithmSign = 5;
 
 	public ArithmeticCaptchaAbstract() {
 		setLen(2);
@@ -24,24 +37,47 @@ public abstract class ArithmeticCaptchaAbstract extends Captcha {
 	 */
 	@Override
 	protected char[] alphas() {
-		StringBuilder sb = new StringBuilder();
+		List<String> arithmeticList = new ArrayList<>(len + len - 1);
+		Symbol lastSymbol = null;
+		int divAmount = 0;
 		for (int i = 0; i < len; i++) {
-			sb.append(num(difficulty));
+			int number = num(difficulty);
+
+			// 如果上一步生成的为除号，要重新设置除数和被除数，确保难度满足设定要求且可以整除
+			if (lastSymbol == Symbol.DIV) {
+				number = (int) Math.sqrt(number);
+				// 避免被除数为 0
+				number = number == 0 ? 1 : number;
+				arithmeticList.set(2 * (i - 1), String.valueOf(number * num((int) Math.sqrt(difficulty))));
+			}
+
+			arithmeticList.add(String.valueOf(number));
+
 			if (i < len - 1) {
-				int type = num(1, algorithmSign);
+				int type;
+
+				// 除法只出现一次，否则还需要递归更新除数，第一个除数将会很大
+				if (divAmount == 1) {
+					type = num(1, algorithmSign - 1);
+				} else {
+					type = num(1, algorithmSign);
+				}
+
 				if (type == 1) {
-					sb.append(Symbol.ADD.getValue());
+					arithmeticList.add((lastSymbol = Symbol.ADD).getValue());
 				} else if (type == 2) {
-					sb.append(Symbol.SUB.getValue());
+					arithmeticList.add((lastSymbol = Symbol.SUB).getValue());
 				} else if (type == 3) {
-					sb.append(Symbol.MUL.getValue());
+					arithmeticList.add((lastSymbol = Symbol.MUL).getValue());
+				} else if (type == 4) {
+					arithmeticList.add((lastSymbol = Symbol.DIV).getValue());
+					divAmount++;
 				}
 			}
 		}
-
-		chars = String.valueOf(AviatorEvaluator.execute(sb.toString().replace("x", "*")));
-		sb.append("=?");
-		arithmeticString = sb.toString();
+		arithmeticString = String.join("", arithmeticList);
+		chars = String.valueOf(AviatorEvaluator.execute(arithmeticString.replace("x", "*").replace("÷", "/")));
+		arithmeticString += "=?";
 		return chars.toCharArray();
 	}
 
@@ -55,16 +91,32 @@ public abstract class ArithmeticCaptchaAbstract extends Captcha {
 	}
 
 	public void setDifficulty(int difficulty) {
+		// 做上下界检测，避免越界
+		if (difficulty <= 0) {
+			difficulty = 10;
+		}
 		ArithmeticCaptchaAbstract.difficulty = difficulty;
 	}
 
 	/**
 	 * algorithmSign
-	 * 2 : 支持加法 algorithmSign 3 : 支持加减法 algorithmSign 4 : 支持加减乘法
+	 * <p>2 : 支持加法 algorithmSign
+	 * <p>3 : 支持加减法 algorithmSign
+	 * <p>4 : 支持加减乘法
+	 * <p>5 : 支持加减乘除法
 	 *
 	 * @param algorithmSign 计算公式标示
 	 */
 	public void supportAlgorithmSign(int algorithmSign) {
+
+		// 做上下界检测，避免越界
+		if (algorithmSign < 2) {
+			algorithmSign = 2;
+		}
+
+		if (algorithmSign > 5) {
+			algorithmSign = 5;
+		}
 		ArithmeticCaptchaAbstract.algorithmSign = algorithmSign;
 	}
 

--- a/captcha-core/src/main/java/com/pig4cloud/captcha/engine/Symbol.java
+++ b/captcha-core/src/main/java/com/pig4cloud/captcha/engine/Symbol.java
@@ -27,19 +27,46 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Symbol {
+
 	/**
 	 * 标识符
 	 */
-	NUM('n', false), ADD('+', false), SUB('-', false), MUL('x', true), DIV('÷', true);
+	NUM("n", false),
 
-	private final char value;
+	/**
+	 * 加法
+	 */
+	ADD("+", false),
 
+	/**
+	 * 减发
+	 */
+	SUB("-", false),
+
+	/**
+	 * 乘法
+	 */
+	MUL("x", true),
+
+	/**
+	 * 除法
+	 */
+	DIV("÷", true);
+
+	/**
+	 * 算数符号
+	 */
+	private final String value;
+
+	/**
+	 * 是否优先计算
+	 */
 	private final boolean priority;
 
-	public static Symbol of(char c) {
+	public static Symbol of(String c) {
 		Symbol[] values = Symbol.values();
 		for (Symbol value : values) {
-			if (value.value == c) {
+			if (value.value.equals(c)) {
 				return value;
 			}
 		}


### PR DESCRIPTION
# 修改
1. 不论算式多长，都只有一次除法，否则第一个除数会变得很大
2. 将原来字符串拼接改为放入数组，最后转为一个字符串，这样除法算式在调整除数和被除数的时候能快速索引到位置
3. 算数验证码设置参数时做上下界检测，避免越界
4. 将运算符号枚举里的算数符号属性从 char 改为 string，避免使用时再进行转换
5. 优化注释与格式