### PR TITLE
更新captcha-spring-boot-starter里依赖的captcha-core版本号

### DIFF
--- a/captcha-spring-boot-starter/pom.xml
+++ b/captcha-spring-boot-starter/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.pig4cloud.plugin</groupId>
             <artifactId>captcha-core</artifactId>
-            <version>2.2.3</version>
+            <version>2.2.4</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
修改了captcha-spring-boot-starter依赖的captcha-core版本号：

Before
```xml
        <dependency>
            <groupId>com.pig4cloud.plugin</groupId>
            <artifactId>captcha-core</artifactId>
            <version>2.2.3</version>
        </dependency>
```

After
```xml
        <dependency>
            <groupId>com.pig4cloud.plugin</groupId>
            <artifactId>captcha-core</artifactId>
            <version>2.2.4</version>
        </dependency>
```

可以解决 https://github.com/pig-mesh/easy-captcha/issues/23 提到的字体拷贝错误问题。